### PR TITLE
Block input

### DIFF
--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -62,6 +62,9 @@ class SideMenu extends StatefulWidget {
   /// 4. slide
   final SideMenuType type;
 
+  /// Blocks inputs on the main page when the side menu is open
+  final bool blockInput;
+
   /// Liquid Shrink Side Menu is compatible with [Liquid ui](https://pub.dev/packages/liquid_ui)
   ///
   /// Create a SideMenu / Drawer
@@ -106,6 +109,7 @@ class SideMenu extends StatefulWidget {
     required this.menu,
     this.type = SideMenuType.shrikNRotate,
     this.maxMenuWidth = 275.0,
+    this.blockInput = false,
     bool inverse = false,
   })  : assert(maxMenuWidth > 0),
         _inverse = inverse ? -1 : 1,

--- a/lib/src/shrik_slide_menu.dart
+++ b/lib/src/shrik_slide_menu.dart
@@ -20,15 +20,18 @@ class ShrinkSlideSideMenuState extends SideMenuState {
             child: widget.menu,
           ),
           _getCloseButton(statusBarHeight),
-          AnimatedContainer(
-            duration: const Duration(milliseconds: 350),
-            curve: Curves.fastLinearToSlowEaseIn,
-            alignment: Alignment.topLeft,
-            transform: _getMatrix4(size),
-            decoration: BoxDecoration(
-              borderRadius: _getBorderRadius(),
+          IgnorePointer(
+            ignoring: widget.blockInput && _opened,
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 350),
+              curve: Curves.fastLinearToSlowEaseIn,
+              alignment: Alignment.topLeft,
+              transform: _getMatrix4(size),
+              decoration: BoxDecoration(
+                borderRadius: _getBorderRadius(),
+              ),
+              child: _getChild(),
             ),
-            child: _getChild(),
           ),
         ],
       ),

--- a/lib/src/shrink_slide_rotate_menu.dart
+++ b/lib/src/shrink_slide_rotate_menu.dart
@@ -20,19 +20,22 @@ class ShrinkSlideRotateSideMenuState extends SideMenuState {
             child: widget.menu,
           ),
           _getCloseButton(statusBarHeight),
-          AnimatedContainer(
-            duration: const Duration(milliseconds: 350),
-            curve: Curves.fastLinearToSlowEaseIn,
-            transform: _getMatrix4(size),
-            decoration: BoxDecoration(
-                borderRadius: _getBorderRadius(),
-                boxShadow: [
-                  BoxShadow(
-                      offset: Offset(0, 18.0),
-                      color: Colors.black12,
-                      blurRadius: 32.0)
-                ]),
-            child: _getChild(),
+          IgnorePointer(
+            ignoring: widget.blockInput && _opened,
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 350),
+              curve: Curves.fastLinearToSlowEaseIn,
+              transform: _getMatrix4(size),
+              decoration: BoxDecoration(
+                  borderRadius: _getBorderRadius(),
+                  boxShadow: [
+                    BoxShadow(
+                        offset: Offset(0, 18.0),
+                        color: Colors.black12,
+                        blurRadius: 32.0)
+                  ]),
+              child: _getChild(),
+            ),
           ),
         ],
       ),

--- a/lib/src/slide_menu.dart
+++ b/lib/src/slide_menu.dart
@@ -19,12 +19,15 @@ class SlideSideMenuState extends SideMenuState {
             child: widget.menu,
           ),
           _getCloseButton(statusBarHeight),
-          AnimatedContainer(
-            duration: const Duration(milliseconds: 350),
-            curve: Curves.fastLinearToSlowEaseIn,
-            alignment: Alignment.topLeft,
-            transform: _getMatrix4(size),
-            child: widget.child,
+          IgnorePointer(
+            ignoring: widget.blockInput && _opened,
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 350),
+              curve: Curves.fastLinearToSlowEaseIn,
+              alignment: Alignment.topLeft,
+              transform: _getMatrix4(size),
+              child: widget.child,
+            ),
           ),
         ],
       ),

--- a/lib/src/slide_rotate_menu.dart
+++ b/lib/src/slide_rotate_menu.dart
@@ -20,19 +20,22 @@ class SlideRotateSideMenuState extends SideMenuState {
             child: widget.menu,
           ),
           _getCloseButton(statusBarHeight),
-          AnimatedContainer(
-            duration: const Duration(milliseconds: 350),
-            curve: Curves.fastLinearToSlowEaseIn,
-            transform: _getMatrix4(size),
-            decoration: BoxDecoration(
-                borderRadius: _getBorderRadius(),
-                boxShadow: [
-                  BoxShadow(
-                      offset: Offset(0, 18.0),
-                      color: Colors.black12,
-                      blurRadius: 32.0)
-                ]),
-            child: _getChild(),
+          IgnorePointer(
+            ignoring: widget.blockInput && _opened,
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 350),
+              curve: Curves.fastLinearToSlowEaseIn,
+              transform: _getMatrix4(size),
+              decoration: BoxDecoration(
+                  borderRadius: _getBorderRadius(),
+                  boxShadow: [
+                    BoxShadow(
+                        offset: Offset(0, 18.0),
+                        color: Colors.black12,
+                        blurRadius: 32.0)
+                  ]),
+              child: _getChild(),
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
While implementing this package in our app to improve the esthetics of our side menu we noticed that the inputs are still able to be processed by the main page when the side menu is open. I've tried to circumvent this issue by wrapping the scaffold in an ignore pointer but there is no way to let our ignore pointer know that the close button has been pressed. Thus I propose this change which would allow the input to the main page to be blocked if preferred. This would not be a breaking change but simply add an extra option to the Side Menu.