### PR TITLE
Refactor based on `flutter_lints`

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,10 @@
+# This file configures the analyzer, which statically analyzes Dart code to
+# check for errors, warnings, and lints.
+#
+# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
+# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
+# invoked from the command line by running `flutter analyze`.
+
+# The following line activates a set of recommended lints for Flutter apps,
+# packages, and plugins designed to encourage good coding practices.
+include: package:flutter_lints/flutter.yaml

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -49,7 +49,7 @@ class SideMenu extends StatefulWidget {
   /// generally a [SingleChildScrollView] with a [Column]
   final Widget menu;
 
-  /// Maximum constrints for menu width
+  /// Maximum constraints for menu width
   ///
   /// default: `275.0`
   final double maxMenuWidth;
@@ -96,14 +96,14 @@ class SideMenu extends StatefulWidget {
   ///
   const SideMenu({
     Key key,
-    this.child,
+    @required this.child,
     this.background,
     this.radius,
     this.closeIcon = const Icon(
       Icons.close,
-      color: const Color(0xFFFFFFFF),
+      color: Color(0xFFFFFFFF),
     ),
-    this.menu,
+    @required this.menu,
     this.type = SideMenuType.shrikNRotate,
     this.maxMenuWidth = 275.0,
     bool inverse = false,
@@ -125,13 +125,20 @@ class SideMenu extends StatefulWidget {
   bool get inverse => _inverse == -1;
 
   @override
+  // ignore: no_logic_in_create_state
   SideMenuState createState() {
-    if (type == SideMenuType.shrikNRotate)
-      return ShrinkSlideRotateSideMenuState();
-    if (type == SideMenuType.shrinkNSlide) return ShrinkSlideSideMenuState();
-    if (type == SideMenuType.slide) return SlideSideMenuState();
-    if (type == SideMenuType.slideNRotate) return SlideRotateSideMenuState();
-    return null;
+    switch (type) {
+      case SideMenuType.shrikNRotate:
+        return ShrinkSlideRotateSideMenuState();
+      case SideMenuType.shrinkNSlide:
+        return ShrinkSlideSideMenuState();
+      case SideMenuType.slideNRotate:
+        return SlideSideMenuState();
+      case SideMenuType.slide:
+        return SlideRotateSideMenuState();
+    }
+
+    throw UnsupportedError('Unsupported SideMenuType.');
   }
 }
 

--- a/lib/src/shrink_slide_rotate_menu.dart
+++ b/lib/src/shrink_slide_rotate_menu.dart
@@ -26,7 +26,7 @@ class ShrinkSlideRotateSideMenuState extends SideMenuState {
             transform: _getMatrix4(size),
             decoration: BoxDecoration(
                 borderRadius: _getBorderRadius(),
-                boxShadow: [
+                boxShadow: const [
                   BoxShadow(
                       offset: Offset(0, 18.0),
                       color: Colors.black12,

--- a/lib/src/slide_rotate_menu.dart
+++ b/lib/src/slide_rotate_menu.dart
@@ -26,7 +26,7 @@ class SlideRotateSideMenuState extends SideMenuState {
             transform: _getMatrix4(size),
             decoration: BoxDecoration(
                 borderRadius: _getBorderRadius(),
-                boxShadow: [
+                boxShadow: const [
                   BoxShadow(
                       offset: Offset(0, 18.0),
                       color: Colors.black12,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -55,25 +55,46 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -127,7 +148,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:
@@ -141,6 +162,6 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_lints: ^1.0.0
+
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
Hi amazing developer,

This library is already a great completion, but I have noticed that some of the coding does not follow Dart or Flutter standards because it does not use flutter_lints.

Therefore, I have made the following fixes.

- Added `flutter_lints` to `pubspec.yaml`
- Added `analysis_options.yaml`
- Fixed some lines based on `flutter_lints` suggestions (**Not destructive**)

Thank you.